### PR TITLE
Clean up source, fix duplication bug.

### DIFF
--- a/src/com/rit/sucy/CustomEnchantment.java
+++ b/src/com/rit/sucy/CustomEnchantment.java
@@ -1,9 +1,10 @@
 package com.rit.sucy;
 
-import com.rit.sucy.service.ENameParser;
-import com.rit.sucy.service.ERomanNumeral;
-import com.rit.sucy.service.MaterialClass;
-import com.rit.sucy.service.MaterialsParser;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -20,10 +21,10 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.rit.sucy.service.ENameParser;
+import com.rit.sucy.service.ERomanNumeral;
+import com.rit.sucy.service.MaterialClass;
+import com.rit.sucy.service.MaterialsParser;
 
 /**
  * Base class for custom enchantments

--- a/src/com/rit/sucy/EnchantmentAPI.java
+++ b/src/com/rit/sucy/EnchantmentAPI.java
@@ -1,14 +1,13 @@
 package com.rit.sucy;
 
-import com.rit.sucy.Anvil.AnvilListener;
-import com.rit.sucy.commands.Commander;
-import com.rit.sucy.config.RootConfig;
-import com.rit.sucy.enchanting.*;
-import com.rit.sucy.lore.LoreConfig;
-import com.rit.sucy.service.ENameParser;
-import com.rit.sucy.service.ERomanNumeral;
-import com.rit.sucy.service.IModule;
-import com.rit.sucy.service.PermissionNode;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
@@ -21,7 +20,18 @@ import org.bukkit.permissions.Permissible;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.*;
+import com.rit.sucy.anvil.AnvilListener;
+import com.rit.sucy.commands.Commander;
+import com.rit.sucy.config.RootConfig;
+import com.rit.sucy.enchanting.EEquip;
+import com.rit.sucy.enchanting.EListener;
+import com.rit.sucy.enchanting.VanillaData;
+import com.rit.sucy.enchanting.VanillaEnchantment;
+import com.rit.sucy.lore.LoreConfig;
+import com.rit.sucy.service.ENameParser;
+import com.rit.sucy.service.ERomanNumeral;
+import com.rit.sucy.service.IModule;
+import com.rit.sucy.service.PermissionNode;
 
 /**
  * Contains methods to register and access custom enchantments

--- a/src/com/rit/sucy/anvil/AnvilMechanics.java
+++ b/src/com/rit/sucy/anvil/AnvilMechanics.java
@@ -1,13 +1,16 @@
-package com.rit.sucy.Anvil;
+package com.rit.sucy.anvil;
 
-import com.rit.sucy.CustomEnchantment;
-import com.rit.sucy.EnchantmentAPI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.*;
+import com.rit.sucy.CustomEnchantment;
+import com.rit.sucy.EnchantmentAPI;
 
 /**
  * Custom implementation of anvil mechanics to accommodate for custom enchantments

--- a/src/com/rit/sucy/anvil/AnvilTask.java
+++ b/src/com/rit/sucy/anvil/AnvilTask.java
@@ -1,4 +1,4 @@
-package com.rit.sucy.Anvil;
+package com.rit.sucy.anvil;
 
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;

--- a/src/com/rit/sucy/anvil/AnvilView.java
+++ b/src/com/rit/sucy/anvil/AnvilView.java
@@ -1,4 +1,4 @@
-package com.rit.sucy.Anvil;
+package com.rit.sucy.anvil;
 
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;

--- a/src/com/rit/sucy/anvil/CustomAnvil.java
+++ b/src/com/rit/sucy/anvil/CustomAnvil.java
@@ -1,6 +1,8 @@
-package com.rit.sucy.Anvil;
+package com.rit.sucy.anvil;
 
-import com.rit.sucy.config.LanguageNode;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -11,8 +13,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.Plugin;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.rit.sucy.config.LanguageNode;
 
 public class CustomAnvil implements AnvilView, Listener {
 

--- a/src/com/rit/sucy/anvil/MainAnvil.java
+++ b/src/com/rit/sucy/anvil/MainAnvil.java
@@ -1,18 +1,19 @@
-package com.rit.sucy.Anvil;
+package com.rit.sucy.anvil;
 
-import net.minecraft.server.v1_7_R1.ContainerAnvil;
-import net.minecraft.server.v1_7_R1.ContainerAnvilInventory;
-import net.minecraft.server.v1_7_R1.IInventory;
+import java.lang.reflect.Field;
+
+import net.minecraft.server.v1_7_R4.ContainerAnvil;
+import net.minecraft.server.v1_7_R4.ContainerAnvilInventory;
+import net.minecraft.server.v1_7_R4.IInventory;
+
 import org.bukkit.ChatColor;
-import org.bukkit.craftbukkit.v1_7_R1.entity.CraftPlayer;
-import org.bukkit.craftbukkit.v1_7_R1.inventory.CraftInventoryAnvil;
-import org.bukkit.craftbukkit.v1_7_R1.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_7_R4.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_7_R4.inventory.CraftInventoryAnvil;
+import org.bukkit.craftbukkit.v1_7_R4.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
-
-import java.lang.reflect.Field;
 
 public class MainAnvil implements AnvilView {
 
@@ -46,7 +47,7 @@ public class MainAnvil implements AnvilView {
     public String getNameText() {
         try {
             // Make sure the item doesn't have a unique name
-            for (net.minecraft.server.v1_7_R1.ItemStack item : inv.getIngredientsInventory().getContents()) {
+            for (net.minecraft.server.v1_7_R4.ItemStack item : inv.getIngredientsInventory().getContents()) {
                 ItemStack i = CraftItemStack.asBukkitCopy(item);
                 if (i.hasItemMeta() && i.getItemMeta().hasDisplayName() && !i.getItemMeta().getDisplayName().equals(ChatColor.stripColor(i.getItemMeta().getDisplayName()))) {
                     return null;
@@ -63,7 +64,7 @@ public class MainAnvil implements AnvilView {
             // More gross (Reflection to obtain the first item)
             Field g = ContainerAnvil.class.getDeclaredField("h");
             g.setAccessible(true);
-            net.minecraft.server.v1_7_R1.ItemStack item = ((IInventory)g.get(anvil)).getItem(0);
+            net.minecraft.server.v1_7_R4.ItemStack item = ((IInventory)g.get(anvil)).getItem(0);
             if (item == null)
                 return null;
 

--- a/src/com/rit/sucy/commands/AddEnchantCommand.java
+++ b/src/com/rit/sucy/commands/AddEnchantCommand.java
@@ -1,14 +1,15 @@
 package com.rit.sucy.commands;
 
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
 import com.rit.sucy.CustomEnchantment;
 import com.rit.sucy.EnchantmentAPI;
 import com.rit.sucy.service.ENameParser;
 import com.rit.sucy.service.ICommand;
 import com.rit.sucy.service.PermissionNode;
-import org.bukkit.ChatColor;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 
 /**
  * Adds an enchantment to an item

--- a/src/com/rit/sucy/commands/BookCommand.java
+++ b/src/com/rit/sucy/commands/BookCommand.java
@@ -1,10 +1,8 @@
 package com.rit.sucy.commands;
 
-import com.rit.sucy.CustomEnchantment;
-import com.rit.sucy.EnchantmentAPI;
-import com.rit.sucy.enchanting.VanillaEnchantment;
-import com.rit.sucy.service.ENameParser;
-import com.rit.sucy.service.ICommand;
+import java.util.ArrayList;
+import java.util.Collections;
+
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.command.Command;
@@ -13,8 +11,11 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import com.rit.sucy.CustomEnchantment;
+import com.rit.sucy.EnchantmentAPI;
+import com.rit.sucy.enchanting.VanillaEnchantment;
+import com.rit.sucy.service.ENameParser;
+import com.rit.sucy.service.ICommand;
 
 /**
  * Provides the executor with a book containing descriptions for all enchantments

--- a/src/com/rit/sucy/commands/Commander.java
+++ b/src/com/rit/sucy/commands/Commander.java
@@ -1,12 +1,13 @@
 package com.rit.sucy.commands;
 
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
 import com.rit.sucy.EnchantmentAPI;
 import com.rit.sucy.service.CommandHandler;
 import com.rit.sucy.service.ICommand;
 import com.rit.sucy.service.PermissionNode;
-import org.bukkit.ChatColor;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
 
 public class Commander extends CommandHandler
 {

--- a/src/com/rit/sucy/commands/EnchantListCommand.java
+++ b/src/com/rit/sucy/commands/EnchantListCommand.java
@@ -1,17 +1,18 @@
 package com.rit.sucy.commands;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
 import com.rit.sucy.CustomEnchantment;
 import com.rit.sucy.EnchantmentAPI;
 import com.rit.sucy.enchanting.VanillaEnchantment;
 import com.rit.sucy.service.ICommand;
 import com.rit.sucy.service.PermissionNode;
-import org.bukkit.ChatColor;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
 
 /**
  * List all custom Enchantments

--- a/src/com/rit/sucy/commands/GraphCommand.java
+++ b/src/com/rit/sucy/commands/GraphCommand.java
@@ -1,14 +1,15 @@
 package com.rit.sucy.commands;
 
-import com.rit.sucy.CustomEnchantment;
-import com.rit.sucy.EnchantmentAPI;
-import com.rit.sucy.service.ENameParser;
-import com.rit.sucy.service.ICommand;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.inventory.ItemStack;
+
+import com.rit.sucy.CustomEnchantment;
+import com.rit.sucy.EnchantmentAPI;
+import com.rit.sucy.service.ENameParser;
+import com.rit.sucy.service.ICommand;
 
 /**
  * Displays a graph to the sender for the probability statistics for an item's enchantment

--- a/src/com/rit/sucy/commands/GraphTask.java
+++ b/src/com/rit/sucy/commands/GraphTask.java
@@ -1,10 +1,8 @@
 package com.rit.sucy.commands;
 
-import com.rit.sucy.CustomEnchantment;
-import com.rit.sucy.EnchantmentAPI;
-import com.rit.sucy.config.RootConfig;
-import com.rit.sucy.config.RootNode;
-import com.rit.sucy.enchanting.EEnchantTable;
+import java.text.DecimalFormat;
+import java.util.Hashtable;
+import java.util.Map;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -12,9 +10,11 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
-import java.text.DecimalFormat;
-import java.util.Hashtable;
-import java.util.Map;
+import com.rit.sucy.CustomEnchantment;
+import com.rit.sucy.EnchantmentAPI;
+import com.rit.sucy.config.RootConfig;
+import com.rit.sucy.config.RootNode;
+import com.rit.sucy.enchanting.EEnchantTable;
 
 /**
  * Displays a graph for the probabilities of an enchantment on a weapon

--- a/src/com/rit/sucy/commands/ReloadCommand.java
+++ b/src/com/rit/sucy/commands/ReloadCommand.java
@@ -1,10 +1,11 @@
 package com.rit.sucy.commands;
 
-import com.rit.sucy.EnchantmentAPI;
-import com.rit.sucy.service.ICommand;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+
+import com.rit.sucy.EnchantmentAPI;
+import com.rit.sucy.service.ICommand;
 
 /**
  * @author Diemex

--- a/src/com/rit/sucy/commands/StatCommand.java
+++ b/src/com/rit/sucy/commands/StatCommand.java
@@ -1,12 +1,13 @@
 package com.rit.sucy.commands;
 
-import com.rit.sucy.EnchantmentAPI;
-import com.rit.sucy.service.ICommand;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.inventory.ItemStack;
+
+import com.rit.sucy.EnchantmentAPI;
+import com.rit.sucy.service.ICommand;
 
 /**
  * Displays enchantment probability statistics for an item

--- a/src/com/rit/sucy/commands/StatTask.java
+++ b/src/com/rit/sucy/commands/StatTask.java
@@ -1,5 +1,16 @@
 package com.rit.sucy.commands;
 
+import java.text.DecimalFormat;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+
 import com.rit.sucy.CustomEnchantment;
 import com.rit.sucy.EnchantmentAPI;
 import com.rit.sucy.config.RootConfig;
@@ -7,14 +18,6 @@ import com.rit.sucy.config.RootNode;
 import com.rit.sucy.enchanting.EEnchantTable;
 import com.rit.sucy.enchanting.VanillaEnchantment;
 import com.rit.sucy.service.ENameParser;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.command.CommandSender;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
-
-import java.text.DecimalFormat;
-import java.util.*;
 
 /**
  * Handles calculating item enchantment probability statistics

--- a/src/com/rit/sucy/config/EnchantmentNode.java
+++ b/src/com/rit/sucy/config/EnchantmentNode.java
@@ -1,9 +1,9 @@
 package com.rit.sucy.config;
 
+import java.util.Collections;
+
 import com.rit.sucy.CustomEnchantment;
 import com.rit.sucy.service.ConfigNode;
-
-import java.util.Collections;
 
 /**
  * @author Diemex

--- a/src/com/rit/sucy/config/LanguageNode.java
+++ b/src/com/rit/sucy/config/LanguageNode.java
@@ -1,9 +1,9 @@
 package com.rit.sucy.config;
 
-import com.rit.sucy.service.ConfigNode;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import com.rit.sucy.service.ConfigNode;
 
 public enum LanguageNode implements ConfigNode {
 

--- a/src/com/rit/sucy/config/RootConfig.java
+++ b/src/com/rit/sucy/config/RootConfig.java
@@ -1,18 +1,23 @@
 package com.rit.sucy.config;
 
-import com.rit.sucy.CustomEnchantment;
-import com.rit.sucy.EnchantmentAPI;
-import com.rit.sucy.enchanting.VanillaEnchantment;
-import com.rit.sucy.service.MaterialsParser;
-import com.rit.sucy.service.ModularConfig;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.*;
+import com.rit.sucy.CustomEnchantment;
+import com.rit.sucy.EnchantmentAPI;
+import com.rit.sucy.enchanting.VanillaEnchantment;
+import com.rit.sucy.service.MaterialsParser;
+import com.rit.sucy.service.ModularConfig;
 
 /**
  * Configuration handler for the root config.yml file.

--- a/src/com/rit/sucy/enchanting/EEnchantTable.java
+++ b/src/com/rit/sucy/enchanting/EEnchantTable.java
@@ -1,13 +1,19 @@
 package com.rit.sucy.enchanting;
 
-import com.rit.sucy.CustomEnchantment;
-import com.rit.sucy.EnchantmentAPI;
-import com.rit.sucy.service.MaterialClass;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.*;
+import com.rit.sucy.CustomEnchantment;
+import com.rit.sucy.EnchantmentAPI;
+import com.rit.sucy.service.MaterialClass;
 
 /**
  * Handles selecting enchantments when enchanting items

--- a/src/com/rit/sucy/enchanting/EEquip.java
+++ b/src/com/rit/sucy/enchanting/EEquip.java
@@ -1,13 +1,14 @@
 package com.rit.sucy.enchanting;
 
-import com.rit.sucy.EnchantmentAPI;
-import com.rit.sucy.service.ENameParser;
+import java.util.Hashtable;
+
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.scheduler.BukkitRunnable;
 
-import java.util.Hashtable;
+import com.rit.sucy.EnchantmentAPI;
+import com.rit.sucy.service.ENameParser;
 
 /**
  * Handles keeping track of player equipment for Equip and Unequip enchantment effects

--- a/src/com/rit/sucy/enchanting/EListener.java
+++ b/src/com/rit/sucy/enchanting/EListener.java
@@ -1,12 +1,11 @@
 package com.rit.sucy.enchanting;
 
-import com.rit.sucy.CustomEnchantment;
-import com.rit.sucy.EnchantmentAPI;
-import com.rit.sucy.config.LanguageNode;
-import com.rit.sucy.config.RootConfig;
-import com.rit.sucy.config.RootNode;
-import com.rit.sucy.service.ENameParser;
-import com.rit.sucy.service.PermissionNode;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -27,13 +26,22 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.inventory.InventoryType;
-import org.bukkit.event.player.*;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerItemBreakEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.EnchantingInventory;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.*;
+import com.rit.sucy.CustomEnchantment;
+import com.rit.sucy.EnchantmentAPI;
+import com.rit.sucy.config.LanguageNode;
+import com.rit.sucy.config.RootConfig;
+import com.rit.sucy.config.RootNode;
+import com.rit.sucy.service.ENameParser;
+import com.rit.sucy.service.PermissionNode;
 
 /**
  * Listens for events and passes them onto enchantments
@@ -83,7 +91,7 @@ public class EListener implements Listener {
 
         LivingEntity damaged = (LivingEntity)event.getEntity();
         LivingEntity damager = event.getDamager() instanceof LivingEntity ? (LivingEntity) event.getDamager()
-                : event.getDamager() instanceof Projectile ? ((Projectile)event.getDamager()).getShooter()
+                : event.getDamager() instanceof Projectile ? (LivingEntity) ((Projectile)event.getDamager()).getShooter()
                 : null;
         if (event.getCause() != EntityDamageEvent.DamageCause.ENTITY_ATTACK
                 && event.getCause() != EntityDamageEvent.DamageCause.PROJECTILE) return;
@@ -252,8 +260,8 @@ public class EListener implements Listener {
     public void onProjectile(ProjectileLaunchEvent event) {
         if (event.getEntity().getShooter() == null)
             return;
-        for (Map.Entry<CustomEnchantment, Integer> entry : getValidEnchantments(getItems(event.getEntity().getShooter())).entrySet()) {
-            entry.getKey().applyProjectileEffect(event.getEntity().getShooter(), entry.getValue(), event);
+        for (Map.Entry<CustomEnchantment, Integer> entry : getValidEnchantments(getItems((LivingEntity) event.getEntity().getShooter())).entrySet()) {
+            entry.getKey().applyProjectileEffect((LivingEntity) event.getEntity().getShooter(), entry.getValue(), event);
         }
     }
 
@@ -264,8 +272,7 @@ public class EListener implements Listener {
      */
     @EventHandler
     public void onClick(InventoryClickEvent event) {
-        Inventory inv = event.getInventory();
-        if (event.getInventory().getType() == InventoryType.ENCHANTING && event.isShiftClick()) {
+        if (event.getInventory().getType() == InventoryType.ENCHANTING) {
             if (tasks.containsKey(event.getWhoClicked().getName())) {
                 tasks.get(event.getWhoClicked().getName()).restore();
             }

--- a/src/com/rit/sucy/enchanting/EnchantResult.java
+++ b/src/com/rit/sucy/enchanting/EnchantResult.java
@@ -1,9 +1,10 @@
 package com.rit.sucy.enchanting;
 
-import com.rit.sucy.CustomEnchantment;
+import java.util.Map;
+
 import org.bukkit.inventory.ItemStack;
 
-import java.util.Map;
+import com.rit.sucy.CustomEnchantment;
 
 public class EnchantResult {
 

--- a/src/com/rit/sucy/enchanting/TableTask.java
+++ b/src/com/rit/sucy/enchanting/TableTask.java
@@ -1,8 +1,8 @@
 package com.rit.sucy.enchanting;
 
-import com.rit.sucy.EUpdateTask;
-import com.rit.sucy.EnchantmentAPI;
-import com.rit.sucy.config.LanguageNode;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -13,8 +13,9 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.rit.sucy.EUpdateTask;
+import com.rit.sucy.EnchantmentAPI;
+import com.rit.sucy.config.LanguageNode;
 
 public class TableTask extends BukkitRunnable {
 

--- a/src/com/rit/sucy/enchanting/VanillaData.java
+++ b/src/com/rit/sucy/enchanting/VanillaData.java
@@ -1,10 +1,11 @@
 package com.rit.sucy.enchanting;
 
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+
 import com.rit.sucy.CustomEnchantment;
 import com.rit.sucy.service.ItemSets;
 import com.rit.sucy.service.SuffixGroups;
-import org.bukkit.Material;
-import org.bukkit.enchantments.Enchantment;
 
 /**
  * Holds information about Enchantments in the vanilla game

--- a/src/com/rit/sucy/enchanting/VanillaEnchantment.java
+++ b/src/com/rit/sucy/enchanting/VanillaEnchantment.java
@@ -1,15 +1,15 @@
 package com.rit.sucy.enchanting;
 
-import com.rit.sucy.CustomEnchantment;
-import com.rit.sucy.service.MaterialClass;
-import org.bukkit.Bukkit;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.rit.sucy.CustomEnchantment;
+import com.rit.sucy.service.MaterialClass;
 
 /**
  * @author Diemex

--- a/src/com/rit/sucy/lore/LoreConfig.java
+++ b/src/com/rit/sucy/lore/LoreConfig.java
@@ -1,14 +1,13 @@
 package com.rit.sucy.lore;
 
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.plugin.java.JavaPlugin;
-
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Hashtable;
 import java.util.List;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
 
 public class LoreConfig {
 

--- a/src/com/rit/sucy/service/CommandHandler.java
+++ b/src/com/rit/sucy/service/CommandHandler.java
@@ -1,15 +1,16 @@
 package com.rit.sucy.service;
 
-import com.rit.sucy.EnchantmentAPI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.rit.sucy.EnchantmentAPI;
 
 /**
  * Abstract class to handle the majority of the logic dealing with commands.

--- a/src/com/rit/sucy/service/ENameParser.java
+++ b/src/com/rit/sucy/service/ENameParser.java
@@ -1,13 +1,13 @@
 package com.rit.sucy.service;
 
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
-
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.Map;
 
 /**
  * Parses lore names into enchantment names and levels

--- a/src/com/rit/sucy/service/ICommand.java
+++ b/src/com/rit/sucy/service/ICommand.java
@@ -1,8 +1,9 @@
 package com.rit.sucy.service;
 
-import com.rit.sucy.EnchantmentAPI;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+
+import com.rit.sucy.EnchantmentAPI;
 
 /**
  * Represents a command.

--- a/src/com/rit/sucy/service/MaterialsParser.java
+++ b/src/com/rit/sucy/service/MaterialsParser.java
@@ -1,12 +1,10 @@
 package com.rit.sucy.service;
 
-import org.bukkit.Material;
-
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
+
+import org.bukkit.Material;
 
 /**
  * Parses a given StringList into an Material array

--- a/src/com/rit/sucy/service/ModularConfig.java
+++ b/src/com/rit/sucy/service/ModularConfig.java
@@ -1,12 +1,13 @@
 package com.rit.sucy.service;
 
-import com.rit.sucy.EnchantmentAPI;
-import org.bukkit.configuration.ConfigurationSection;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import com.rit.sucy.EnchantmentAPI;
 
 /**
  * Modular configuration class that utilizes a ConfigNode enumeration as easy


### PR DESCRIPTION
- Update to latest CraftBukkit namespaces.
- Fix a duplication bug where players could duplicate items through anvils.
- Clean up the source a bit; change player names in the task Hashtable to UUIDs.
