### PR TITLE
Update EnchantListener.java

### DIFF
--- a/src/com/sucy/enchant/listener/EnchantListener.java
+++ b/src/com/sucy/enchant/listener/EnchantListener.java
@@ -165,8 +165,7 @@ public class EnchantListener extends BaseListener {
     @EventHandler
     public void onClose(final InventoryCloseEvent event) {
         if (placeholders.containsKey(event.getPlayer().getUniqueId())) {
-            event.getPlayer().getInventory().addItem(placeholders.get(event.getPlayer().getUniqueId()));
-            event.getInventory().clear();
+            event.getInventory().setItem(0, placeholders.remove(event.getPlayer().getUniqueId()));
         }
     }
 


### PR DESCRIPTION
Minecraft 1.12 added the feature to send items directly to the inventory instead of dropping them.
So this may cause some problems like duplication and being cleared the chest inventory.

This pull request fixed the issue.